### PR TITLE
Fix clean

### DIFF
--- a/warp.py
+++ b/warp.py
@@ -108,7 +108,7 @@ def parseCommandLineOptions():
     default=False,
     dest="clean",
     help="remove every generated asset")
-    buildGroup.add_argument("-F", "--force-clean",
+    buildGroup.add_argument("-f", "--force-clean",
     action="store_true",
     default=False,
     dest="force_clean",

--- a/warp.py
+++ b/warp.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-import os, glob, hashlib, pickle, argparse, shutil
+import os, glob, hashlib, pickle, argparse, shutil, ntpath
 
 ######################### Classes ##############################
 class AndroidDensity:
@@ -59,20 +59,24 @@ modifiedFiles = []
 targetPlatform = ""
 shouldCleanProject = False
 shouldRunSilently = False
-versionName = "1.0.0"
+versionName = "1.0.1"
 
 # Script entry point
 def main():
     parseCommandLineOptions()
     greet()
     setUpPathVariables()
-    if shouldCleanProject: cleanProject()
-    makeRequiredDirectories()
-    classifyRawFiles(upToDateFiles, deletedFiles, newFiles, modifiedFiles)
-    processUpToDateAssets(upToDateFiles)
-    processNewAssets(newFiles)
-    processModifiedAssets(modifiedFiles)
-    processDeletedAssets(deletedFiles)
+
+    if shouldCleanProject or shouldForceCleanProject:
+        cleanProject()
+    else:
+        makeRequiredDirectories()
+        classifyRawFiles(upToDateFiles, deletedFiles, newFiles, modifiedFiles)
+        processUpToDateAssets(upToDateFiles)
+        processNewAssets(newFiles)
+        processModifiedAssets(modifiedFiles)
+        processDeletedAssets(deletedFiles)
+
     goodbye()
 
 # Parse command line options and store them in variables
@@ -103,7 +107,12 @@ def parseCommandLineOptions():
     action="store_true",
     default=False,
     dest="clean",
-    help="force every asset to be processed from scratch")
+    help="remove every generated asset")
+    buildGroup.add_argument("-F", "--force-clean",
+    action="store_true",
+    default=False,
+    dest="force_clean",
+    help="forces the removal of the output folder")
 
     uiGroup = parser.add_argument_group('UI')
     uiGroup.add_argument("-s", "--silent",
@@ -117,6 +126,7 @@ def parseCommandLineOptions():
     global dirRaw
     global dirAssets
     global shouldCleanProject
+    global shouldForceCleanProject
     global shouldRunSilently
 
     args = parser.parse_args()
@@ -124,6 +134,7 @@ def parseCommandLineOptions():
     if args.input: dirRaw = args.input
     if args.output: dirAssets = args.output
     shouldCleanProject = args.clean
+    shouldForceCleanProject = args.force_clean
     shouldRunSilently = args.silent
 
 # Greet
@@ -154,11 +165,34 @@ def setUpPathVariables():
 # Clears previously processed assets and the hash storage file
 def cleanProject():
     print(Colors.YELLOW + "Cleaning previously processed assets..." + Colors.ENDC)
-    if dirRaw != "/" and os.path.exists(dirRaw + STORAGE_FILE_NAME):
+    # Dictionary of previously hashed files: <file path, MD5 hash>
+    storedHashedFiles = loadHashedFiles()
+
+    # Delete all the stored files
+    for path, md5 in storedHashedFiles.iteritems():
+        assetToClean = ntpath.basename(path)
+        print(Colors.BLUE + "DELETING ASSET: " + assetToClean + Colors.ENDC)
+        deleteAsset(assetToClean)
+
+    # Remove generated density folders if empty
+    for density in androidDensities:
+        densityDir = dirAssets + density.path
+        if os.path.exists(densityDir) and (os.listdir(densityDir) == [] or shouldForceCleanProject) :
+            print(Colors.BLUE + "DELETING ASSET DIRECTORY: " + densityDir + Colors.ENDC)
+            if shouldForceCleanProject:
+                shutil.rmtree(densityDir)
+            else :
+                os.rmdir(densityDir)
+
+    # Remove assets output folder if empty
+    if os.path.exists(dirAssets) and os.listdir(dirAssets) == [] :
+        print(Colors.BLUE + "DELETING EMPTY OUTPUT DIRECTORY: " + dirAssets + Colors.ENDC)
+        os.rmdir(dirAssets)
+
+    # Remove storage file
+    if os.path.exists(dirRaw + STORAGE_FILE_NAME):
         os.remove(dirRaw + STORAGE_FILE_NAME)
 
-    if dirAssets != "/" and os.path.exists(dirAssets):
-        shutil.rmtree(dirAssets)
     print(Colors.YELLOW + "Assets cleared" + Colors.ENDC)
 
 # Make the required directories to process asssets if they doesn't exist already
@@ -301,8 +335,9 @@ def compressPNG(inputPath):
 # Remove asset in every screen density
 def deleteAsset(assetName):
     for density in androidDensities:
-        os.remove( dirAssets + density.path + assetName)
-        print(assetName + ": DELETED asset for " + density.name)
+        if os.path.exists(dirAssets + density.path + assetName):
+            os.remove(dirAssets + density.path + assetName)
+            print(assetName + ": DELETED asset for " + density.name)
 
 # Goodbye
 def goodbye():

--- a/warp_task.gradle
+++ b/warp_task.gradle
@@ -14,7 +14,7 @@ task warpAssets(type: Exec) {
             ]
 }
 
-task cleanAssets(type: Exec) {
+task cleanWarpAssets(type: Exec) {
     group = 'Optimizations'
     description = 'Clean converted assets'
 
@@ -33,8 +33,7 @@ task cleanAssets(type: Exec) {
 }
 
 preBuild.dependsOn warpAssets
-clean.dependsOn cleanWarpAssets
 
 // Uncomment if you want to clean all the assets when running the "clean" task.
 // Caution: It could take a long time to "Rebuild" or "Clean" Project.
-// clean.dependsOn cleanAssets
+// clean.dependsOn cleanWarpAssets

--- a/warp_task.gradle
+++ b/warp_task.gradle
@@ -2,18 +2,39 @@ task warpAssets(type: Exec) {
     group = 'Optimizations'
     description = 'Convert and optimize assets for every screen density using WARP'
 
-    def absolutePath = file('..') // Get project absolute path
-    def rawPath = "$absolutePath/raw/" // The folder where the raw assets are located
-    def resPath = "$absolutePath/app/src/main/res/" // Android's 'res' folder
+    def rawPath = "$rootDir/raw/" // The folder where the raw assets are located
+    def resPath = "$rootDir/app/src/main/res/" // Android's 'res' folder
 
-    commandLine = '../scripts/warp/warp.py'
+    commandLine = "$rootDir/scripts/warp/warp.py"
     args = [
             '--target', 'android',
             '--input', rawPath,
             '--output', resPath,
             '--silent'
             ]
+}
+
+task cleanAssets(type: Exec) {
+    group = 'Optimizations'
+    description = 'Clean converted assets'
+
+    def rawPath = "$rootDir/raw/" // The folder where the raw assets are located
+    def resPath = "$rootDir/app/src/main/res/" // Android's 'res' folder
+
+    commandLine = "$rootDir/scripts/warp/warp.py"
+    args = [
+            '--target', 'android',
+            '--input', rawPath,
+            '--output', resPath,
+            '--silent',
+            '--clean'
+            ]
 
 }
 
 preBuild.dependsOn warpAssets
+clean.dependsOn cleanWarpAssets
+
+// Uncomment if you want to clean all the assets when running the "clean" task.
+// Caution: It could take a long time to "Rebuild" or "Clean" Project.
+// clean.dependsOn cleanAssets


### PR DESCRIPTION
# Summary
Fix issue on the 'clean' option that removed the output directory. It now removes only the generated files (from the cache) and removes the generated directories only if they are empty.
This also adds a 'force clean' option that will remove the generated directories, even if they are not empty.

Updated the gradle task to use the gradle variables and to avoid using relative paths, also add a clean  task, disabled by default, to clean assets when rebuilding or cleaning project in android studio.

This pull request also changes the flow of the app to avoid processing the assets when cleaning them. This was made to follow the way gradle (and other build tools) works.